### PR TITLE
adds types declaration to package.json so TypeScript can pick them up

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/break_infinity.js",
   "module": "dist/break_infinity.esm.js",
   "unpkg": "dist/break_infinity.min.js",
+  "types": "break_infinity.d.ts",
   "scripts": {
     "build": "npm run dist && npm run docs",
     "dist": "bili",


### PR DESCRIPTION
This adds the types declaration to `package.json` so TSC can actually locate the type definitions when it's inside of `node_modules`. I've verified this works locally for me: without it, my `Decimal` import has no types.

fixes Patashu/break_infinity.js#63
