### PR TITLE
Actually inline `pad-end`

### DIFF
--- a/bili.config.ts
+++ b/bili.config.ts
@@ -18,6 +18,12 @@ const config: Config = {
                     return defaultFileName;
             }
         }
+    },
+    extendConfig: (config) => {
+        return {
+            ...config,
+            externals: []
+        };
     }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs",
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Also removes the `"module": "commonjs"` thing - by default bili actually passes `"module": "esnext"` if no value is specified.

(This took a fucking ton of time to debug :sob: - hopefully, this fixes the issue)